### PR TITLE
Replace #url() with #path()

### DIFF
--- a/managair_server/urls.py
+++ b/managair_server/urls.py
@@ -23,7 +23,7 @@ from drf_spectacular.views import (
 )
 
 urlpatterns = [
-    path(r"", include("user_manager.urls")),
+    path("", include("user_manager.urls")),
     # path('api/auth/', include('rest_framework.urls')),
     path("api/v1/", include("core.urls")),
     path("ingest/v1/", include("ingest.urls")),

--- a/user_manager/urls.py
+++ b/user_manager/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from user_manager.views import dashboard, register
 
 urlpatterns = [
-    url(r"^accounts/", include("django.contrib.auth.urls")),
-    url(r"^dashboard/", dashboard, name="dashboard"),
-    url(r"^register/", register, name="register"),
+    path("accounts/", include("django.contrib.auth.urls")),
+    path("dashboard/", dashboard, name="dashboard"),
+    path("register/", register, name="register"),
 ]


### PR DESCRIPTION
The #url() method has been deprecated with Django 3.1
See: https://docs.djangoproject.com/en/3.1/ref/urls/#url