### PR TITLE
Handle static files via White Noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+staticfiles/
 
 # Flask stuff:
 instance/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,13 @@ RUN apt-get update && \
 
 # Docker defaults to sh, but the 'source' command is only available in bash.
 SHELL ["/bin/bash", "-c"] 
-RUN python3 -m venv env && source env/bin/activate
-
 RUN mkdir /code
+
 WORKDIR /code
 # install dependencies
 COPY ./requirements.txt .
 RUN pip3 install --upgrade pip && pip3 install wheel \
-    && pip3 install -r requirements.txt
+    && pip3 install --no-cache-dir -r requirements.txt
 
 # copy application and support scripts
 COPY ./managair_server /code/managair_server

--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,18 @@
 - System administration [Django admin UI]
 - Fidelity check for all registered nodes: Warn if no messages have been received lately [adnin UI].
 
+## Deployment
+
+The Managair is desiged to be deployed as part of the _Clair Stack_, a docker swarm setup that comprises the configuration of all services necessary to ingest node data and serve it via the Managair API to frontend applications.
+
+Even though docker swarm automates most deployment tasks for the entire Clair Stack, there are several tasks that pertain to the Managair service proper:
+
+### Static Files
+
+HTML Templates, CSS, and media for the admin-UI and the browsable API are part of the Managair service. In a typicall web application, it would be the job of a webserver to serve these files - as described in the [Django documentation](https://docs.djangoproject.com/en/3.1/howto/static-files/deployment/.) To simplify configuration, and to align development with production setups, we take a somewhat different route and use the [White Noise](http://whitenoise.evans.io/en/stable/django.html) module instead. With the White Noise middleware installed, Managair can serve its own static files without the help of an additional webserver. This is not quite as performant but requires much less configuration and fewer manual steps during deployment.
+
+Upon a fresh deployment, or whenever static files have changed, you can force Django to collect all static files from all registered Django apps into a common folder by running `python manage.py collectstatic`. The `entrypoint.sh` script of the Managair docker container automatically performs this task if the environment variable `COLLECT_STATIC_FILES` is set to `true`.
+
 ## Development Setup
 
 Managair is a [Django](https://www.djangoproject.com/) web application atop a [PostgreSQL](https://www.postgresql.org) DBMS. It is meant to be run as part of the Clair backend stack. To start up your development environment, consult the stack's Readme-file.
@@ -44,7 +56,6 @@ Make sure to respect the order because of foreign-key constraints. When Managair
 
 - [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 - Linting: [PyLint](https://www.pylint.org)
-
 
 ## OpenAPI Schema
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source env/bin/activate
-
 if [ "$DATABASE" = "postgresql" ]
 then
     echo "Waiting for postgres..."
@@ -17,6 +15,12 @@ doMigrate=${DB_MIGRATE:-false}
 if [ "$doMigrate" = true ] ;
 then
   python manage.py migrate
+fi
+
+doCollectStaticFiles=${COLLECT_STATIC_FILES:-false}
+if [ "$doCollectStaticFiles" = true ] ;
+then
+  python manage.py collectstatic --noinput
 fi
 
 exec "$@"

--- a/managair_server/settings.py
+++ b/managair_server/settings.py
@@ -52,14 +52,14 @@ if SENTRY:
 
 # Application definition
 INSTALLED_APPS = [
+    "whitenoise.runserver_nostatic",
+    "django.contrib.staticfiles",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.sites",
-    "django.contrib.staticfiles",
-    # 'debug_toolbar',
     "django_q",
     "rest_framework",
     "rest_framework.authtoken",
@@ -76,9 +76,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    # 'debug_toolbar.middleware.DebugToolbarMiddleware',
-    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    'whitenoise.middleware.WhiteNoiseMiddleware',
+    "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -237,8 +237,11 @@ USE_L10N = True
 
 USE_TZ = True
 
-
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/3.1/howto/static-files/
-
+# Let White Noise compress static files and make them cacheable.
+# See http://whitenoise.evans.io/en/stable/index.html
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+# Default static files directory
+# See https://docs.djangoproject.com/en/3.1/howto/static-files/
 STATIC_URL = "/static/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ drf-spectacular
 django-filter
 django_q
 redis
+whitenoise[brotli]
 sentry-sdk
 ptvsd
 django-debug-toolbar


### PR DESCRIPTION
- Add the White Noise module to handle static files.
- Add an entrypoint action to collect new static files.
- Add an environment variable to control the entrypoint action.
- Remove Python venv from the container, as it breaks bind-mounts on mac and windows.