### PR TITLE
Access control for membership changes

### DIFF
--- a/core/models/inventory.py
+++ b/core/models/inventory.py
@@ -60,6 +60,10 @@ class Membership(models.Model):
         """Return True if the membership role is OWNER."""
         return self.role == self.OWNER
 
+    def get_owner(self):
+        """Return the organization that is target of the present membership."""
+        return self.organization
+
     class Meta:
         constraints = [
             # Memberships must be unique.

--- a/core/serializers/inventory.py
+++ b/core/serializers/inventory.py
@@ -103,7 +103,9 @@ class RoomNodeInstallationSerializer(serializers.HyperlinkedModelSerializer):
             room = data["room"]
             node = data["node"]
         except KeyError:
-            raise serializers.ValidationError("Both the Room reference and the node reference must be provided.")
+            raise serializers.ValidationError(
+                "Both the Room reference and the node reference must be provided."
+            )
         if room.site.operator != node.owner:
             raise serializers.ValidationError(
                 "In an installation, Node and room must belong to the same owner."
@@ -186,6 +188,10 @@ class MembershipSerializer(serializers.ModelSerializer):
             "role",
             "url",
         )
+
+    def get_owner(self):
+        """Return the owner of the resource, once data is validated."""
+        return self.validated_data["organization"]
 
 
 class OrganizationSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
- A user cannot up- or downgrade its own membership status if he or she is not OWNER of the member-organization.
- A user cannot add someone to an organization where he or she is not OWNER.
- A non-OWNER cannot leave an organization.
- Test cases
- minor cleanup.