### PR TITLE
Allow secrets to be retrieved from files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -93,6 +93,11 @@ The following environment variables are available to influence Managair setup. S
 - `DJANGO_DB_LOG_LEVEL=WARNING`. Log level for DBMS messages only.
 - `DJANGO_LOG_LEVEL=WARNING`. Log level for Django-internal messages.
 
+The following environment variables determine how Managair is launched inside its Docker container, via the `entrypoint.sh` script:
+
+- `DB_MIGRATE=False`. Execute new database migrations upon launch, if available.
+- `COLLECT_STATIC_FILES=False`. Collect static files in a central location to be served via [WhiteNoise](http://whitenoise.evans.io/en/stable/).
+
 ## Development Setup
 
 Managair is a [Django](https://www.djangoproject.com/) web application atop a [PostgreSQL](https://www.postgresql.org) DBMS. It is meant to be run as part of the Clair backend stack. To start up your development environment, consult the stack's Readme-file.

--- a/Readme.md
+++ b/Readme.md
@@ -52,6 +52,47 @@ HTML Templates, CSS, and media for the admin-UI and the browsable API are part o
 
 Upon a fresh deployment, or whenever static files have changed, you can force Django to collect all static files from all registered Django apps into a common folder by running `python manage.py collectstatic`. The `entrypoint.sh` script of the Managair docker container automatically performs this task if the environment variable `COLLECT_STATIC_FILES` is set to `true`.
 
+### Secrets
+
+Managair requires several secrets:
+
+- SECRET_KEY: The standard [Django secret key](https://docs.djangoproject.com/en/3.1/ref/settings/#secret-key) that is used for digital signatures and to derive password salts.
+- SQL_PASSWORD: Password to connect to the main database.
+- EMAIL_HOST_PASSWORD: Password for the SMTP server used for sending mails.
+- SENTRY_URL: When using [Sentry.io](https://sentry.io) as a remote-monitoring service, sentry's ingestion URL is a (weak) secret. Sentry remote monitoring is activated setting the environment variable `SENTRY=True`.
+
+These secrets can be passed in either of two ways:
+
+- As value of an environment variable: For each of the secrets listed above, define an environment variable of the same name; e.g., `SECRET_KEY`.
+- As file content: Managair reads the secret value from a file where the filename must be provided via an environment variable `<secret_name>_FILE`; e.g., `SECRET_KEY_FILE`. This mechanism can be used in combination with [Docker secrets](https://docs.docker.com/engine/swarm/secrets/#use-secrets-in-compose), where Docker provides secrets to services as files inside an encrypted RAM-disk mounted at `/run/secrets/<secret>` inside the container.
+
+### Environment
+
+The following environment variables are available to influence Managair setup. Shown are their default settings:
+
+- `SECRET_KEY` or `SECRET_KEY_FILE`. Secret as explained above.
+- `DEBUG=0`. Set to `1` to use [Django's debug mode](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-DEBUG) with hot reload. Never use in production!
+- `DEBUG_TOOLBAR=0`. Set to `1` to activate the [Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io/en/latest/). Never use in production.
+- `SENTRY=0`. Set to `1` to activate remote monitoring via [Sentry.io](https://sentry.io).
+- `SENTRY_URL`. Secret ingest URL, as explained above.
+- `NODE_FIDELITY=0`. Set to `1`to activate regular monitoring of node traffic. The status of all nodes can be queried via the [API](./doc/api.md) at `/api/v1/fidelity`.
+- `DJANGO_ALLOWED_HOSTS`. Hosts allowed to connect. See the [Django documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#allowed-hosts) for details.
+- `EMAIL_HOST`. Host name of the SMTP server used to send emails. See the [Django email engine](https://docs.djangoproject.com/en/3.1/topics/email/) documentation for details.
+- `EMAIL_PORT=587`. Port of the SMTP server used to send emails.
+- `EMAIL_HOST_USER`. User name to connect to the SMTP server.
+- `EMAIL_HOST_PASSWORD` or `EMAIL_HOST_PASSWORD_FILE`. Secret as explained above.
+- `EMAIL_USE_TLS=True`.
+- `DEFAULT_FROM_EMAIL`. Default Reply-to email address for sent mails.
+- `SQL_ENGINE=django.db.backends.sqlite3`. Default SQL database engine. Do not use SQLite in production. Consult the documentation on [Django database backends](https://docs.djangoproject.com/en/3.1/ref/databases/).
+- `SQL_DATABASE=db.sqlite3`. Name of the main database to connect to.
+- `SQL_USER=user`. Default database user.
+- `SQL_PASSWORD` and `SQL_PASSWORD_FILE`. The database user's password, as explained above.
+- `SQL_HOST=localhost`. Host name on which the DBMS is running.
+- `SQL_PORT=5432`. Port to connect to the DBMS.
+- `LOG_LEVEL=INFO`. Log level for the Managair application. Only messages with log level of the given severity or higher will be logged. Must be one of `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`. See the [Django logging documentation](https://docs.djangoproject.com/en/3.1/topics/logging/) for details.
+- `DJANGO_DB_LOG_LEVEL=WARNING`. Log level for DBMS messages only.
+- `DJANGO_LOG_LEVEL=WARNING`. Log level for Django-internal messages.
+
 ## Development Setup
 
 Managair is a [Django](https://www.djangoproject.com/) web application atop a [PostgreSQL](https://www.postgresql.org) DBMS. It is meant to be run as part of the Clair backend stack. To start up your development environment, consult the stack's Readme-file.

--- a/managair_server/settings.py
+++ b/managair_server/settings.py
@@ -25,7 +25,7 @@ def get_secret_from_env_or_file(secret_name: str):
         with open(key_file_name) as f:
             return f.read().strip()
     else:
-        return os.environ.get("SECRET_KEY")
+        return os.environ.get(secret_name)
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.

--- a/managair_server/settings.py
+++ b/managair_server/settings.py
@@ -15,14 +15,29 @@ from pathlib import Path
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
+
+def get_secret_from_env_or_file(secret_name: str):
+    """Try to read a secret from a one-line text file, if the file name is provided
+    as environment variable <secret_name>_FILE. Otherwise, read the secret from an
+    environment vairable <secret_name>."""
+    key_file_name = os.environ.get(secret_name + "_FILE", None)
+    if key_file_name:
+        with open(key_file_name) as f:
+            return f.read().strip()
+    else:
+        return os.environ.get("SECRET_KEY")
+
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
+# The SECRET_KEY can be read from a file (for use with Docker secrets) or from the
+# environment.
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("SECRET_KEY")
+SECRET_KEY = get_secret_from_env_or_file("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = int(os.environ.get("DEBUG", default=0))
@@ -43,7 +58,7 @@ ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ")
 # Activate Sentry remote error recording.
 if SENTRY:
     sentry_sdk.init(
-        dsn="https://279c821aafab4487a7a3189ccbcf47a9@o454687.ingest.sentry.io/5460530",
+        dsn=get_secret_from_env_or_file("SENTRY_URL"),
         integrations=[DjangoIntegration()],
         traces_sample_rate=0.0,
         # If you wish to associate users to errors (assuming you are using
@@ -154,12 +169,14 @@ REST_FRAMEWORK = {
 }
 
 # Email Setup
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 # EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 EMAIL_HOST = os.environ.get("EMAIL_HOST")
 EMAIL_PORT = int(os.environ.get("EMAIL_PORT", default=587))
 EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
-EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
+# The EMAIL_HOST_PASSWORD can be read from a file (for use with Docker secrets) or from
+# the environment.
+EMAIL_HOST_PASSWORD = get_secret_from_env_or_file("EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = bool(os.environ.get("EMAIL_USE_TLS", default=True))
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL")
 
@@ -168,13 +185,13 @@ AUTHENTICATION_BACKENDS = (
     # Needed to login by username in Django admin, regardless of `allauth`
     "django.contrib.auth.backends.ModelBackend",
     # `allauth` specific authentication methods, such as login by e-mail
-    "allauth.account.auth_backends.AuthenticationBackend"
+    "allauth.account.auth_backends.AuthenticationBackend",
 )
 
 # See https://dj-rest-auth.readthedocs.io/en/latest/installation.html
 REST_SESSION_LOGIN = True
 SITE_ID = 1
-ACCOUNT_EMAIL_REQUIRED = True # User needs to provide an email address.
+ACCOUNT_EMAIL_REQUIRED = True  # User needs to provide an email address.
 ACCOUNT_AUTHENTICATION_METHOD = "username_email"
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_EMAIL_SUBJECT_PREFIX = "[Clair Plattform] "
@@ -190,7 +207,7 @@ DATABASES = {
         "ENGINE": os.environ.get("SQL_ENGINE", "django.db.backends.sqlite3"),
         "NAME": os.environ.get("SQL_DATABASE", os.path.join(BASE_DIR, "db.sqlite3")),
         "USER": os.environ.get("SQL_USER", "user"),
-        "PASSWORD": os.environ.get("SQL_PASSWORD", "password"),
+        "PASSWORD": get_secret_from_env_or_file("SQL_PASSWORD"),
         "HOST": os.environ.get("SQL_HOST", "localhost"),
         "PORT": os.environ.get("SQL_PORT", "5432"),
     }


### PR DESCRIPTION
Secrets can now be passed as files, in addition to values of environment variables.

- provide the file name as `<secret_name>_FILE`.
- Available secrets to be passed as files:
  - SECRET_KEY
  - SQL_PASSWORD
  - EMAIL_HOST_PASSWORD
  - SENTRY_URL

To use the file-based method, please change the compose files of the Clair Stack accordingly.