### PR TITLE
Fix a bug in the installation PATCH method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 staticfiles/
+media/
 
 # Flask stuff:
 instance/

--- a/core/serializers/inventory.py
+++ b/core/serializers/inventory.py
@@ -136,16 +136,12 @@ class RoomNodeInstallationSerializer(serializers.HyperlinkedModelSerializer):
         logger.debug(
             "For a new or updated installation, validate that node and room belong to the same owner."
         )
-        try:
-            room = attrs["room"]
-            node = attrs["node"]
-        except KeyError:
+        siteOperator = attrs["room"].site.operator if "room" in attrs else None
+        nodeOwner = attrs["node"].owner if "node" in attrs else None
+
+        if siteOperator != nodeOwner:
             raise serializers.ValidationError(
-                "Both the Room reference and the node reference must be provided."
-            )
-        if room.site.operator != node.owner:
-            raise serializers.ValidationError(
-                "In an installation, Node and room must belong to the same owner."
+                "In an installation, node and room must belong to the same owner."
             )
         return attrs
 

--- a/core/test/test_api_rooms_installations.py
+++ b/core/test/test_api_rooms_installations.py
@@ -325,7 +325,6 @@ class InstallationsTestCase(TokenAuthMixin, APITestCase):
                 "id": self.inst_pk,
                 "attributes": {"from_timestamp_s": 1601510000, "is_public": True},
                 "relationships": {
-                    # Node and room must always be provided, to make sure owners match.
                     "node": {
                         "data": {
                             "type": format_resource_type("Node"),
@@ -345,6 +344,23 @@ class InstallationsTestCase(TokenAuthMixin, APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["from_timestamp_s"], 1601510000)
         self.assertEqual(response.data["is_public"], True)
+
+    def test_toggle_installation_publicity(self):
+        """PATCH /installations/<installation_pk>/"""
+        request_data = {
+            "data": {
+                "type": format_resource_type("Installation"),
+                "id": self.inst_pk,
+                "attributes": {"is_public": True},
+            },
+        }
+        response = self.client.patch(self.detail_url, data=request_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["is_public"], True)
+        request_data["data"]["attributes"]["is_public"] = False
+        response = self.client.patch(self.detail_url, data=request_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["is_public"], False)
 
     # TODO: Test illegal time-slice overlaps
 


### PR DESCRIPTION
The installation serializer's validation is too strict. It ensures that the owner of the site and the node connected via an installation is the same. However, when simply updating the ìs_private`flag, these relations are not provided.

Resolves #106.