### PR TITLE
feat: Build psycopg2 from source for multiplatform support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:slim-buster
 RUN apt-get update && \
     apt-get -y dist-upgrade && \
-    apt-get -y install apt-utils netcat gettext
+    apt-get -y install apt-utils netcat gettext gcc python3-dev libpq-dev
 
 # Docker defaults to sh, but the 'source' command is only available in bash.
 SHELL ["/bin/bash", "-c"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==4.0.4
-psycopg2-binary==2.9.3
+psycopg2==2.9.3
 djangorestframework==3.13.1
 djangorestframework-jsonapi==5.0.0
 dj-rest-auth[with_social]==2.2.4


### PR DESCRIPTION
Switch from binary to source distribution, so that we can support multiple microprocessor architectures. This requires build tools (gcc, Python C-headers) as part of the image. In the future, we should use a more clever docker build, so that build tools do not end up in the final image.